### PR TITLE
Font Style Variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A colour palette can be added to the border as well.
 
 ## Installation
 
-```bash 
+```bash
 git clone https://github.com/stevequinn/photoborder
 ```
 
@@ -58,6 +58,22 @@ The repo comes with [Roboto](https://fonts.google.com/specimen/Roboto) (Regular,
 ```photoborder/fonts```
 
 Should you wish to use another font you should add it to the ```fonts``` directory and use the appropriate arguments
+
+## Testing
+
+There are some very simple tests available in the `tests/` directory.
+
+You can run these with:
+
+```bash
+pytest -s ./tests
+```
+
+For specific test modules just do the same for the file like so:
+
+```bash
+pytest -s ./tests/test_text.py
+```
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ positional arguments:
   filename
 
 options:
-  -h, --help            show this help message and exit
-  -e, --exif            print photo exif data on the border
-  -p, --palette         Add colour palette to the photo border
-  -t, --border_type     Border Type: p for polaroid, s for small, m for medium, l for large, i for instagram (default: s)
-  -f, -font             Font Typeface to use
-  -fb, --font bold      Bold Font Typeface to use
-  --include             File patterns to include (default: *.jpg *.jpeg *.png, *.JPG, *.JPEG, *.PNG)
-  --exclude             File patterns to exclude (default: *_border*)
+  -h, --help              Show this help message and exit
+  -e, --exif              Print photo exif data on the border
+  -p, --palette           Add colour palette to the photo border
+  -t, --border_type       Border Type: p for polaroid, s for small, m for medium, l for large, i for instagram (default: s)
+  -f, --font              Font Typeface to use (default: Roboto-Regular.ttf)
+  -fv, --fontvariant      Font style variant to use (default: 0)
+  -fb, --fontbold         Bold Font Typeface to use (default: Roboto-Medium.ttf)
+  -fbv, --fontboldvariant Bold Font style variant to use (default: 0)
+  --include               File patterns to include (default: *.jpg *.jpeg *.png, *.JPG, *.JPEG, *.PNG)
+  --exclude               File patterns to exclude (default: *_border*)
 
 Made for fun and to solve a little problem.
 ```

--- a/border.py
+++ b/border.py
@@ -123,13 +123,13 @@ def draw_border(img: Image, border: Border) -> Image:
 
     return canvas
 
-def draw_exif(img: Image, exif: dict, border: Border, fontpath: str, boldfontpath: str) -> Image:
+def draw_exif(img: Image, exif: dict, border: Border, font: tuple[str, int], boldfont: tuple[str, int]) -> Image:
     centered = border.border_type in (BorderType.POLAROID, BorderType.LARGE, BorderType.INSTAGRAM)
     multiplier = 0.2 if centered else 0.5
-    font_size = tm.get_optimal_font_size("Test string", border.bottom * multiplier, fontpath)
-    heading_font_size = tm.get_optimal_font_size("Test string", border.bottom * (multiplier + 0.02), boldfontpath)
-    font = tm.create_font(font_size, fontpath)
-    heading_font = tm.create_font(heading_font_size, boldfontpath)
+    font_size = tm.get_optimal_font_size("Test", border.bottom * multiplier, font[0], index=font[1])
+    heading_font_size = tm.get_optimal_font_size("Test", border.bottom * (multiplier + 0.02), boldfont[0], index=boldfont[1])
+    font = tm.create_font(font_size, fontpath=font[0], index=font[1])
+    heading_font = tm.create_font(heading_font_size, fontpath=boldfont[0], index=boldfont[1])
 
     # Vertical align text in bottom border based on total font block height.
     if centered:

--- a/main.py
+++ b/main.py
@@ -42,12 +42,17 @@ def parse_arguments():
                         help='File patterns to exclude (default: *_border*)')
     parser.add_argument('-f', '--font', default='Roboto-Regular.ttf',
                         help='Font file in fonts directory')
+    parser.add_argument('-fv', '--fontvariant', default=0, type=int,
+                        help='Font style variant index')
     parser.add_argument('-fb', '--fontbold', default='Roboto-Medium.ttf',
                         help='Bold font file in fonts directory')
+    parser.add_argument('-fbv', '--fontboldvariant', default=0, type=int,
+                        help='Bold font style variant index')
     return parser.parse_args()
 
 
-def process_image(path: str, add_exif: bool, add_palette: bool, border_type: BorderType, fontname: str, boldfontname: str) -> str:
+def process_image(path: str, add_exif: bool, add_palette: bool, border_type: BorderType,
+                  font: tuple[str, int], boldfont: tuple[str, int]) -> str:
     """ Add a border to an image
     Supported image types ['jpg', 'jpeg', 'png'].
 
@@ -57,8 +62,8 @@ def process_image(path: str, add_exif: bool, add_palette: bool, border_type: Bor
         add_palette (bool): Add colour palette information to the border.
                             Currently only supported on Polaroid border types.
         border_type (BorderType): The type of border to add to the photo.
-        fontname (str): name of the font file to use
-        boldfontname (str): name of the bold font file to use
+        font: tuple[str, int]: (fontName, fontVariantIndex)
+        boldfont: tuple[str, int]: (fontName, fontVariantIndex)
     """
     filetypes = ['jpg', 'jpeg', 'png']
     path_dot_parts = path.split('.')
@@ -80,16 +85,16 @@ def process_image(path: str, add_exif: bool, add_palette: bool, border_type: Bor
         if exif:
             moduledir = os.path.dirname(os.path.abspath(__file__))
             fontdir = os.path.join(moduledir, "fonts")
-            font_path = os.path.join(fontdir, fontname)
-            bold_font_path = os.path.join(fontdir, boldfontname)
+            font_path = os.path.join(fontdir, font[0])
+            bold_font_path = os.path.join(fontdir, boldfont[0])
 
-            # Validate fonts before processing any images
-            error_messages = [f"Font '{f}' not found in the font directory." for f in [
-                font_path, bold_font_path] if not validate_font(f)]
+            # Exit early if a problem exists with the fonts
+            error_messages = [err for f in [(font_path, font[1]), (bold_font_path, boldfont[1])]
+                              if (err := validate_font(fontpath=f[0], index=f[1]))]
             if len(error_messages) > 0:
                 raise ValueError(error_messages)
 
-            img_with_border = draw_exif(img_with_border, exif, border, font_path, bold_font_path)
+            img_with_border = draw_exif(img_with_border, exif, border, (font_path, font[1]), (bold_font_path, boldfont[1]))
             save_as = f'{save_as}_exif'
 
     if add_palette:
@@ -146,7 +151,8 @@ def main():
 
     for path in paths:
         logger.info(f'Adding border to {path}')
-        save_path = process_image(path, args.exif, args.palette, args.border_type, args.font, args.fontbold)
+        save_path = process_image(path=path, add_exif=args.exif, add_palette=args.palette, border_type=args.border_type,
+                                  font=(args.font, args.fontvariant) , boldfont=(args.fontbold, args.fontboldvariant))
         logger.info(f'Saved as {save_path}')
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from text import validate_font
 
 # Enable logging
 logging.basicConfig(
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
+    format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S'
 )
 logger = logging.getLogger(__name__)
 

--- a/tests/test_exif.py
+++ b/tests/test_exif.py
@@ -5,5 +5,3 @@ def test_ExifItem():
     assert str(itm) == '23mm'
     itm = ExifItem('UnknownItem', ' Bleh  ')
     assert str(itm) == 'Bleh'
-
-

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+from PIL import ImageFont
+from text import create_font, load_font_variants
+
+
+
+def test_font_index():
+    fontname = 'Roboto-Regular.ttf'
+    moduledir = os.path.dirname(os.path.abspath(__file__))
+    fontdir = os.path.join(moduledir, "../fonts")
+    font_path = os.path.join(fontdir, fontname)
+    index = 20
+    variants = []
+
+    try:
+        font = create_font(size=12, fontpath=font_path, index=index)
+    except Exception:
+        variants = load_font_variants(fontpath=font_path)
+        print(f'Error loading {fontname} font variant {index}. Available variants: {variants}')
+        assert len(variants) is not 0
+
+    for variant in variants:
+        try:
+            font = create_font(size=12, fontpath=font_path, index=variant[0])
+            print(f'{variant[1]} loaded')
+        except Exception as exc:
+            pytest.fail(f'Unexpected eception raised: {exc}')
+
+


### PR DESCRIPTION
Adds support for font style variants to be passed in as a parameter. 

```bash
python main.py -e -t p -f 'Roboto-Regular.ttf' -fv 0 -fb 'Roboto-Medium.ttf' -fbv 0 image.jpg 
```

Passing invalid variants will result in detailed error reporting:

```bash
2024-11-19 09:47:50,291 - __main__ - ERROR - ["Font /Users/steveq/dev/whiteborder/fonts/Roboto-Regular.ttf does not contain a variant with index: 1. Available variants: [(0, {'family': 'Roboto', 'style': 'Regular'})]"]
```